### PR TITLE
reviewing rust idioms 

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,23 +1,23 @@
 #[derive(Debug)]
 pub enum Expr {
-  BinOp {
-    op: Operator,
-    a: Box<Expr>,
-    b: Box<Expr>,
-  },
-  Call {
-    target: String,
-    args: Vec<Expr>,
-  },
-  Num {
-    val: f64,
-  },
+    BinOp {
+        op: Operator,
+        a: Box<Expr>,
+        b: Box<Expr>,
+    },
+    Call {
+        target: String,
+        args: Vec<Expr>,
+    },
+    Num {
+        val: f64,
+    },
 }
 
 #[derive(Debug)]
 pub enum Operator {
-  Plus,
-  Minus,
-  Multiply,
-  Divide,
+    Plus,
+    Minus,
+    Multiply,
+    Divide,
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,12 +1,9 @@
 use crate::ast::{Expr, Operator};
 
-pub fn eval(expr: &Expr) -> Result<f64, String> {
+pub fn eval(expr: Expr) -> Result<f64, String> {
     match expr {
         Expr::Call { args, target } => {
-            let mut arg_results = vec![];
-            for arg in args {
-                arg_results.push(eval(arg)?);
-            }
+            let arg_results = args.into_iter().map(eval).collect::<Result<Vec<_>, _>>()?;
 
             let res = match target.as_str() {
                 "Pi" => std::f64::consts::PI,
@@ -20,15 +17,15 @@ pub fn eval(expr: &Expr) -> Result<f64, String> {
             Ok(res)
         }
 
-        Expr::Num { val } => Ok(*val),
+        Expr::Num { val } => Ok(val),
 
         Expr::BinOp {
             op,
             a: a_node,
             b: b_node,
         } => {
-            let a = eval(a_node)?;
-            let b = eval(b_node)?;
+            let a = eval(*a_node)?;
+            let b = eval(*b_node)?;
             let res = match op {
                 Operator::Plus => a + b,
                 Operator::Minus => a - b,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,49 +1,49 @@
 use crate::ast::{Expr, Operator};
 
 pub fn eval(expr: &Expr) -> Result<f64, String> {
-  return match expr {
-    Expr::Call { args, target } => {
-      let mut arg_results = vec![];
-      for arg in args {
-        arg_results.push(eval(arg)?);
-      }
+    match expr {
+        Expr::Call { args, target } => {
+            let mut arg_results = vec![];
+            for arg in args {
+                arg_results.push(eval(arg)?);
+            }
 
-      let res = match target.as_str() {
-        "Pi" => std::f64::consts::PI,
-        "Sin" => arg_results[0].sin(), // how to index a vec or return Err in a not verbose way here?
-        "Cos" => arg_results[0].cos(),
-        "Tan" => arg_results[0].tan(),
-        "Sum" => sum(&arg_results),
-        _ => return Err(format!("unknown function: {}", target)),
-      };
+            let res = match target.as_str() {
+                "Pi" => std::f64::consts::PI,
+                "Sin" => arg_results[0].sin(), // how to index a vec or return Err in a not verbose way here?
+                "Cos" => arg_results[0].cos(),
+                "Tan" => arg_results[0].tan(),
+                "Sum" => sum(&arg_results),
+                _ => return Err(format!("unknown function: {}", target)),
+            };
 
-      return Ok(res);
+            Ok(res)
+        }
+
+        Expr::Num { val } => Ok(*val),
+
+        Expr::BinOp {
+            op,
+            a: a_node,
+            b: b_node,
+        } => {
+            let a = eval(a_node)?;
+            let b = eval(b_node)?;
+            let res = match op {
+                Operator::Plus => a + b,
+                Operator::Minus => a - b,
+                Operator::Multiply => a * b,
+                Operator::Divide => a / b,
+            };
+            Ok(res)
+        }
     }
-
-    Expr::Num { val } => Ok(*val),
-
-    Expr::BinOp {
-      op,
-      a: a_node,
-      b: b_node,
-    } => {
-      let a = eval(a_node)?;
-      let b = eval(b_node)?;
-      let res = match op {
-        Operator::Plus => a + b,
-        Operator::Minus => a - b,
-        Operator::Multiply => a * b,
-        Operator::Divide => a / b,
-      };
-      return Ok(res);
-    }
-  };
 }
 
-fn sum(args: &Vec<f64>) -> f64 {
-  let mut sum: f64 = 0.0;
-  for arg in args {
-    sum += arg;
-  }
-  return sum;
+fn sum(args: &[f64]) -> f64 {
+    let mut sum: f64 = 0.0;
+    for arg in args {
+        sum += arg;
+    }
+    sum
 }

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -2,96 +2,97 @@ use regex;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TokenTy {
-  Whitespace,
-  Ident,
-  Number,
-  LParen,
-  RParen,
-  Comma,
-  Operator,
-  EOF,
+    Whitespace,
+    Ident,
+    Number,
+    LParen,
+    RParen,
+    Comma,
+    Operator,
+    EOF,
 }
 
 #[derive(Clone, Debug)]
 pub struct Token {
-  pub text: String,
-  pub ty: TokenTy,
+    pub text: String,
+    pub ty: TokenTy,
 }
 
 struct Matcher {
-  re: regex::Regex,
-  ty: TokenTy,
-  keep: bool,
+    re: regex::Regex,
+    ty: TokenTy,
+    keep: bool,
 }
 
 pub fn lex(input: &str) -> Result<Vec<Token>, String> {
-  let matchers = build_matchers();
+    let matchers = build_matchers();
 
-  let mut tokens = vec![];
-  let mut idx = 0;
-  while idx < input.len() {
-    let mut found_match = false;
-    for matcher in &matchers {
-      let match_res = matcher.re.find(&input[idx..]);
-      match match_res {
-        Some(x) => {
-          let tok = Token {
-            text: String::from(x.as_str()),
-            ty: matcher.ty,
-          };
-          idx += tok.text.len();
-          if matcher.keep {
-            tokens.push(tok);
-          }
-          found_match = true;
-          break;
+    let mut tokens = vec![];
+    let mut idx = 0;
+    while idx < input.len() {
+        let mut found_match = false;
+        for matcher in &matchers {
+            let match_res = matcher.re.find(&input[idx..]);
+            match match_res {
+                Some(x) => {
+                    let tok = Token {
+                        text: String::from(x.as_str()),
+                        ty: matcher.ty,
+                    };
+                    idx += tok.text.len();
+                    if matcher.keep {
+                        tokens.push(tok);
+                    }
+                    found_match = true;
+                    break;
+                }
+                _ => continue,
+            }
         }
-        _ => continue,
-      }
+        if !found_match {
+            return Err(format!("Could not parse token at idx: {}", idx));
+        };
     }
-    if !found_match {
-      return Err(format!("Could not parse token at idx: {}", idx));
-    };
-  }
-  return Ok(tokens);
+    Ok(tokens)
 }
 
+#[allow(clippy::trivial_regex)]
 fn build_matchers() -> Vec<Matcher> {
-  return vec![
-    Matcher {
-      re: regex::Regex::new(r"^[\s\n]+").unwrap(),
-      ty: TokenTy::Whitespace,
-      keep: false,
-    },
-    Matcher {
-      re: regex::Regex::new(r"^[a-zA-Z][a-zA-Z0-9]*").unwrap(),
-      ty: TokenTy::Ident,
-      keep: true,
-    },
-    Matcher {
-      re: regex::Regex::new(r"^[0-9]+(\.[0-9]+)?").unwrap(),
-      ty: TokenTy::Number,
-      keep: true,
-    },
-    Matcher {
-      re: regex::Regex::new(r"^\(").unwrap(),
-      ty: TokenTy::LParen,
-      keep: true,
-    },
-    Matcher {
-      re: regex::Regex::new(r"^\)").unwrap(),
-      ty: TokenTy::RParen,
-      keep: true,
-    },
-    Matcher {
-      re: regex::Regex::new(r"^,").unwrap(),
-      ty: TokenTy::Comma,
-      keep: true,
-    },
-    Matcher {
-      re: regex::Regex::new(r"^[+\-\*/]").unwrap(),
-      ty: TokenTy::Operator,
-      keep: true,
-    },
-  ];
+    return vec![
+        Matcher {
+            re: regex::Regex::new(r"^[\s\n]+").unwrap(),
+            ty: TokenTy::Whitespace,
+            keep: false,
+        },
+        Matcher {
+            re: regex::Regex::new(r"^[a-zA-Z][a-zA-Z0-9]*").unwrap(),
+            ty: TokenTy::Ident,
+            keep: true,
+        },
+        Matcher {
+            re: regex::Regex::new(r"^[0-9]+(\.[0-9]+)?").unwrap(),
+            ty: TokenTy::Number,
+            keep: true,
+        },
+        Matcher {
+            re: regex::Regex::new(r"^\(").unwrap(),
+            ty: TokenTy::LParen,
+            keep: true,
+        },
+        Matcher {
+            re: regex::Regex::new(r"^\)").unwrap(),
+            ty: TokenTy::RParen,
+            keep: true,
+        },
+        Matcher {
+            re: regex::Regex::new(r"^,").unwrap(),
+            ty: TokenTy::Comma,
+            keep: true,
+        },
+        Matcher {
+            re: regex::Regex::new(r"^[+\-\*/]").unwrap(),
+            ty: TokenTy::Operator,
+            keep: true,
+        },
+    ];
 }

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -13,8 +13,8 @@ pub enum TokenTy {
 }
 
 #[derive(Clone, Debug)]
-pub struct Token {
-    pub text: String,
+pub struct Token<'a> {
+    pub text: &'a str,
     pub ty: TokenTy,
 }
 
@@ -24,7 +24,10 @@ struct Matcher {
     keep: bool,
 }
 
-pub fn lex(input: &str) -> Result<Vec<Token>, String> {
+// A token contains a slice of the input text. As such we can
+// declare that the token's lifetime will not outlive that of
+// the input text - this is the behavior of the lifetime `'a`
+pub fn lex<'a>(input: &'a str) -> Result<Vec<Token<'a>>, String> {
     let matchers = build_matchers();
 
     let mut tokens = vec![];
@@ -36,7 +39,7 @@ pub fn lex(input: &str) -> Result<Vec<Token>, String> {
             match match_res {
                 Some(x) => {
                     let tok = Token {
-                        text: String::from(x.as_str()),
+                        text: x.as_str(),
                         ty: matcher.ty,
                     };
                     idx += tok.text.len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,17 +7,17 @@ use interpreter::eval;
 use parse::parse;
 
 fn main() {
-  let args: Vec<String> = std::env::args().collect();
-  if args.len() < 2 {
-    println!("Usage: rformula \"Cos(Pi() * 2)\"")
-  } else {
-    match run(args[1].as_str()) {
-      Ok(res) => println!("{}", res),
-      Err(msg) => println!("Error: {}", msg),
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        println!("Usage: rformula \"Cos(Pi() * 2)\"")
+    } else {
+        match run(args[1].as_str()) {
+            Ok(res) => println!("{}", res),
+            Err(msg) => println!("Error: {}", msg),
+        }
     }
-  }
 }
 
 fn run(code: &str) -> Result<f64, String> {
-  return eval(&parse(code)?);
+    eval(&parse(code)?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod interpreter;
 mod lex;
 mod parse;
 mod test;
+
 use interpreter::eval;
 use parse::parse;
 
@@ -19,5 +20,5 @@ fn main() {
 }
 
 fn run(code: &str) -> Result<f64, String> {
-    eval(&parse(code)?)
+    eval(parse(code)?)
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,8 +1,8 @@
 use crate::ast::{Expr, Operator};
 use crate::lex::{lex, Token, TokenTy};
 
-pub struct Ctx {
-    tokens: Vec<Token>,
+pub struct Ctx<'a> {
+    tokens: Vec<Token<'a>>,
     idx: usize,
 }
 
@@ -12,24 +12,24 @@ pub fn parse(code: &str) -> Result<Expr, String> {
     parse_bin_op_or_expr(&mut ctx)
 }
 
-fn peek(ctx: &mut Ctx) -> Token {
+fn peek<'a>(ctx: &mut Ctx<'a>) -> Token<'a> {
     if ctx.idx >= ctx.tokens.len() {
         return Token {
-            text: String::from(""),
+            text: "",
             ty: TokenTy::EOF,
         };
     }
     ctx.tokens[ctx.idx].clone()
 }
 
-fn consume(ctx: &mut Ctx) -> Token {
+fn consume<'a>(ctx: &mut Ctx<'a>) -> Token<'a> {
     let tok = peek(ctx);
     ctx.idx += 1;
     tok
 }
 
 // TODO all these should be Result
-fn expect(ctx: &mut Ctx, ty: TokenTy) -> Result<Token, String> {
+fn expect<'a>(ctx: &mut Ctx<'a>, ty: TokenTy) -> Result<Token<'a>, String> {
     let tok = consume(ctx);
     if tok.ty != ty {
         return Err(format!("expected: {:?}, found {:?}", ty, tok.ty));
@@ -46,7 +46,7 @@ fn parse_bin_op_or_expr(ctx: &mut Ctx) -> Result<Expr, String> {
     let mut expr = parse_expr(ctx)?;
     while peek(ctx).ty == TokenTy::Operator {
         let op_token = consume(ctx);
-        let op = match op_token.text.as_str() {
+        let op = match op_token.text {
             "+" => Operator::Plus,
             "-" => Operator::Minus,
             "*" => Operator::Multiply,
@@ -84,7 +84,7 @@ fn parse_call(ctx: &mut Ctx) -> Result<Expr, String> {
     expect(ctx, TokenTy::RParen)?;
 
     Ok(Expr::Call {
-        target: tok.text,
+        target: tok.text.to_string(),
         args,
     })
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,111 +2,111 @@ use crate::ast::{Expr, Operator};
 use crate::lex::{lex, Token, TokenTy};
 
 pub struct Ctx {
-  tokens: Vec<Token>,
-  idx: usize,
+    tokens: Vec<Token>,
+    idx: usize,
 }
 
 pub fn parse(code: &str) -> Result<Expr, String> {
-  let tokens = lex(code)?;
-  let mut ctx = Ctx { tokens, idx: 0 };
-  return parse_bin_op_or_expr(&mut ctx);
+    let tokens = lex(code)?;
+    let mut ctx = Ctx { tokens, idx: 0 };
+    parse_bin_op_or_expr(&mut ctx)
 }
 
 fn peek(ctx: &mut Ctx) -> Token {
-  if ctx.idx >= ctx.tokens.len() {
-    return Token {
-      text: String::from(""),
-      ty: TokenTy::EOF,
-    };
-  }
-  return ctx.tokens[ctx.idx].clone();
+    if ctx.idx >= ctx.tokens.len() {
+        return Token {
+            text: String::from(""),
+            ty: TokenTy::EOF,
+        };
+    }
+    ctx.tokens[ctx.idx].clone()
 }
 
 fn consume(ctx: &mut Ctx) -> Token {
-  let tok = peek(ctx);
-  ctx.idx += 1;
-  return tok;
+    let tok = peek(ctx);
+    ctx.idx += 1;
+    tok
 }
 
 // TODO all these should be Result
 fn expect(ctx: &mut Ctx, ty: TokenTy) -> Result<Token, String> {
-  let tok = consume(ctx);
-  if tok.ty != ty {
-    return Err(format!("expected: {:?}, found {:?}", ty, tok.ty));
-  }
-  return Ok(tok);
+    let tok = consume(ctx);
+    if tok.ty != ty {
+        return Err(format!("expected: {:?}, found {:?}", ty, tok.ty));
+    }
+    Ok(tok)
 }
 
 fn parse_bin_op_or_expr(ctx: &mut Ctx) -> Result<Expr, String> {
-  // here we parse an expression, then look ahead to see if there's a operator after, and keep consuming expressions and operators until we've got em alloc
-  // for now we'll just stuff all operators into the left
-  // a+b+c+d -> (((a+b)+c)+d)
-  // TODO: do precidence and associativity as a post processing step at the end of this fn.
+    // here we parse an expression, then look ahead to see if there's a operator after, and keep consuming expressions and operators until we've got em alloc
+    // for now we'll just stuff all operators into the left
+    // a+b+c+d -> (((a+b)+c)+d)
+    // TODO: do precidence and associativity as a post processing step at the end of this fn.
 
-  let mut expr = parse_expr(ctx)?;
-  while peek(ctx).ty == TokenTy::Operator {
-    let op_token = consume(ctx);
-    let op = match op_token.text.as_str() {
-      "+" => Operator::Plus,
-      "-" => Operator::Minus,
-      "*" => Operator::Multiply,
-      "/" => Operator::Divide,
-      _ => return Err(format!("unsupported operator: {}", op_token.text)),
-    };
-    let a = Box::new(expr);
-    let b = Box::new(parse_expr(ctx)?);
-    expr = Expr::BinOp { op, a, b }
-  }
-  return Ok(expr);
+    let mut expr = parse_expr(ctx)?;
+    while peek(ctx).ty == TokenTy::Operator {
+        let op_token = consume(ctx);
+        let op = match op_token.text.as_str() {
+            "+" => Operator::Plus,
+            "-" => Operator::Minus,
+            "*" => Operator::Multiply,
+            "/" => Operator::Divide,
+            _ => return Err(format!("unsupported operator: {}", op_token.text)),
+        };
+        let a = Box::new(expr);
+        let b = Box::new(parse_expr(ctx)?);
+        expr = Expr::BinOp { op, a, b }
+    }
+    Ok(expr)
 }
 
 fn parse_expr(ctx: &mut Ctx) -> Result<Expr, String> {
-  return match peek(ctx).ty {
-    TokenTy::Ident => parse_call(ctx),
-    TokenTy::Number => parse_num(ctx),
-    TokenTy::LParen => parse_paren_expr(ctx),
-    t => Err(format!("unexpected token: {:?}", t)),
-  };
+    match peek(ctx).ty {
+        TokenTy::Ident => parse_call(ctx),
+        TokenTy::Number => parse_num(ctx),
+        TokenTy::LParen => parse_paren_expr(ctx),
+        t => Err(format!("unexpected token: {:?}", t)),
+    }
 }
 
 fn parse_paren_expr(ctx: &mut Ctx) -> Result<Expr, String> {
-  expect(ctx, TokenTy::LParen)?;
-  let expr = parse_bin_op_or_expr(ctx);
-  expect(ctx, TokenTy::RParen)?;
+    expect(ctx, TokenTy::LParen)?;
+    let expr = parse_bin_op_or_expr(ctx);
+    expect(ctx, TokenTy::RParen)?;
 
-  return expr;
+    expr
 }
 
 fn parse_call(ctx: &mut Ctx) -> Result<Expr, String> {
-  let tok = expect(ctx, TokenTy::Ident)?;
-  expect(ctx, TokenTy::LParen)?;
-  let args = parse_args(ctx)?;
-  expect(ctx, TokenTy::RParen)?;
+    let tok = expect(ctx, TokenTy::Ident)?;
+    expect(ctx, TokenTy::LParen)?;
+    let args = parse_args(ctx)?;
+    expect(ctx, TokenTy::RParen)?;
 
-  return Ok(Expr::Call {
-    target: tok.text.clone(),
-    args,
-  });
+    Ok(Expr::Call {
+        target: tok.text,
+        args,
+    })
 }
 
 fn parse_num(ctx: &mut Ctx) -> Result<Expr, String> {
-  let tok = expect(ctx, TokenTy::Number)?;
-  return Ok(Expr::Num {
-    val: tok.text.parse::<f64>().unwrap(),
-  });
+    let tok = expect(ctx, TokenTy::Number)?;
+    Ok(Expr::Num {
+        val: tok.text.parse::<f64>().unwrap(),
+    })
 }
 
 fn parse_args(ctx: &mut Ctx) -> Result<Vec<Expr>, String> {
-  let mut args = vec![];
+    let mut args = vec![];
 
-  while peek(ctx).ty != TokenTy::RParen {
-    let arg = parse_bin_op_or_expr(ctx)?;
-    args.push(arg);
+    while peek(ctx).ty != TokenTy::RParen {
+        let arg = parse_bin_op_or_expr(ctx)?;
+        args.push(arg);
 
-    if peek(ctx).ty == TokenTy::Comma {
-      consume(ctx);
+        if peek(ctx).ty == TokenTy::Comma {
+            consume(ctx);
+        }
     }
-  }
 
-  return Ok(args);
+    Ok(args)
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -13,7 +13,7 @@ mod tests {
     }
 
     fn parse_and_eval(code: &str, expected: f64) {
-        assert_delta!(eval(&parse(code).unwrap()).unwrap(), expected, 1e-6);
+        assert_delta!(eval(parse(code).unwrap()).unwrap(), expected, 1e-6);
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,44 +1,44 @@
 #[cfg(test)]
 mod tests {
-  use crate::interpreter::eval;
-  use crate::parse::parse;
+    use crate::interpreter::eval;
+    use crate::parse::parse;
 
-  // https://stackoverflow.com/questions/30856285/assert-eq-with-floating-point-numbers-and-delta
-  macro_rules! assert_delta {
-    ($x:expr, $y:expr, $d:expr) => {
-      if !($x - $y < $d || $y - $x < $d) {
-        panic!();
-      }
-    };
-  }
+    // https://stackoverflow.com/questions/30856285/assert-eq-with-floating-point-numbers-and-delta
+    macro_rules! assert_delta {
+        ($x:expr, $y:expr, $d:expr) => {
+            if !($x - $y < $d || $y - $x < $d) {
+                panic!();
+            }
+        };
+    }
 
-  fn parse_and_eval(code: &str, expected: f64) {
-    assert_delta!(eval(&parse(code).unwrap()).unwrap(), expected, 1e-6);
-  }
+    fn parse_and_eval(code: &str, expected: f64) {
+        assert_delta!(eval(&parse(code).unwrap()).unwrap(), expected, 1e-6);
+    }
 
-  #[test]
-  fn bin_op() {
-    parse_and_eval("2 + 2", 4.0);
-    parse_and_eval("2 - 3", -1.0);
-    parse_and_eval("2 * 3", 6.0);
-    parse_and_eval("2 / 2", 1.0);
-    parse_and_eval("(2 + 2)", 4.0);
-    parse_and_eval("2 + 3 - 6", -1.0);
-    parse_and_eval("((2 + 3) - 6)", -1.0);
-    parse_and_eval("(2 + (3 - 6))", -1.0);
-    parse_and_eval("(2 - (3 - 6))", 5.0);
-  }
+    #[test]
+    fn bin_op() {
+        parse_and_eval("2 + 2", 4.0);
+        parse_and_eval("2 - 3", -1.0);
+        parse_and_eval("2 * 3", 6.0);
+        parse_and_eval("2 / 2", 1.0);
+        parse_and_eval("(2 + 2)", 4.0);
+        parse_and_eval("2 + 3 - 6", -1.0);
+        parse_and_eval("((2 + 3) - 6)", -1.0);
+        parse_and_eval("(2 + (3 - 6))", -1.0);
+        parse_and_eval("(2 - (3 - 6))", 5.0);
+    }
 
-  #[test]
-  fn fns() {
-    parse_and_eval("Sum()", 0.0);
-    parse_and_eval("Sum(1)", 1.0);
-    parse_and_eval("Sum(1,2)", 3.0);
-    parse_and_eval("Sum(1,2,3)", 6.0);
+    #[test]
+    fn fns() {
+        parse_and_eval("Sum()", 0.0);
+        parse_and_eval("Sum(1)", 1.0);
+        parse_and_eval("Sum(1,2)", 3.0);
+        parse_and_eval("Sum(1,2,3)", 6.0);
 
-    parse_and_eval("Sin(0)", 0.0);
-    parse_and_eval("Sin(Pi())", 0.0);
-    parse_and_eval("Cos(0)", 1.0);
-    parse_and_eval("Cos(Pi())", -1.0);
-  }
+        parse_and_eval("Sin(0)", 0.0);
+        parse_and_eval("Sin(Pi())", 0.0);
+        parse_and_eval("Cos(0)", 1.0);
+        parse_and_eval("Cos(Pi())", -1.0);
+    }
 }


### PR DESCRIPTION
This patch is split up into a few commits, each of which makes specific changes to the code.

1. This PR contains the results of running `cargo fmt`, and fixing issues surfaced by `cargo clippy`. The first command applies rust's built-in formatting rules - this will rewrite the code in-place. The second command applies rust's built-in linting rules - this will emit warnings and suggestions for addressing the issue(s). 

2. Since the interpreter input isn't reused, it's preferable to visit each node by value, rather than by reference. This way the interpreter only needs to make copies when absolutely necessary. 

3. Since the lexer uses simple slices of the input text, we don't need to make a copy of the substring. These slices also use the lifetime of the input text, which ensures that they do not outlive the input (and thus yield a dangling pointer). 

4. Just fixing up the tests after the changes above 🙂 